### PR TITLE
fixed issue with opening inventory in some scenes

### DIFF
--- a/Zork 1/Assets/Prefabs/Console_UI.prefab
+++ b/Zork 1/Assets/Prefabs/Console_UI.prefab
@@ -221,7 +221,7 @@ MonoBehaviour:
   m_TargetGraphic: {fileID: 8796120413235767315}
   m_HandleRect: {fileID: 2983686744207260973}
   m_Direction: 2
-  m_Value: 0.9998151
+  m_Value: 0.9998152
   m_Size: 0.39667782
   m_NumberOfSteps: 0
   m_OnValueChanged:
@@ -526,8 +526,8 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 1}
-  m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 0, y: 0}
+  m_AnchoredPosition: {x: -48.65, y: 0}
+  m_SizeDelta: {x: -97.3, y: 0}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &7302191689410754265
 CanvasRenderer:

--- a/Zork 1/Assets/Scripts/Buttons/BagButton.cs
+++ b/Zork 1/Assets/Scripts/Buttons/BagButton.cs
@@ -20,6 +20,10 @@ public class BagButton : MonoBehaviour, IPointerClickHandler
         }
     }
     */
+    //private void Start()
+    //{
+    //    Debug.Log("bag button init");
+    //}
 
     private Bag bag;
 

--- a/Zork 1/Assets/Scripts/Inventory/BagScript.cs
+++ b/Zork 1/Assets/Scripts/Inventory/BagScript.cs
@@ -91,7 +91,7 @@ public class BagScript : MonoBehaviour
                     emptySlots++;
                 }
             }
-            Debug.Log(emptySlots);
+            //Debug.Log(emptySlots);
             return emptySlots;
         }
     }

--- a/Zork 1/Assets/Scripts/Inventory/InventoryScript.cs
+++ b/Zork 1/Assets/Scripts/Inventory/InventoryScript.cs
@@ -126,13 +126,14 @@ public class InventoryScript : MonoBehaviour
     //debug
     private void Update()
     {
+        /*
         if (Input.GetKeyDown(KeyCode.L))
         {
             //could I call this on collision?
             /*
             Bag bag = (Bag)Instantiate(items[0]);
             bag.Initialize(16);
-            bag.Use();*/
+            bag.Use();*\/
             //instantiate uses the specified array to make a copy
             //of the object specified.
             //scene view shows weve stored a leaflet item at pos
@@ -146,7 +147,7 @@ public class InventoryScript : MonoBehaviour
             /*
             Bag bag = (Bag)Instantiate(items[0]);
             bag.Initialize(16);
-            bag.Use();*/
+            bag.Use();*\/
             //instantiate uses the specified array to make a copy
             //of the object specified.
             //scene view shows weve stored a leaflet item at pos
@@ -154,6 +155,15 @@ public class InventoryScript : MonoBehaviour
             Egg egg = (Egg)Instantiate(items[2]);
             AddItem(egg);
         }
+        */
+        //test to see if can close bag so I can know if
+        //bag is not working or just not receiving input
+        /*
+        else if (Input.GetKeyDown(KeyCode.X))
+        {
+            MyBags[0].MyBagScript.OpenClose(MyBags[0]);
+        }
+        */
     }
     //end debuggging
 

--- a/Zork 1/ProjectSettings/EditorBuildSettings.asset
+++ b/Zork 1/ProjectSettings/EditorBuildSettings.asset
@@ -335,4 +335,16 @@ EditorBuildSettings:
   - enabled: 1
     path: Assets/Scenes/MachineRoom.unity
     guid: e8a908fbab0c2fa4e8ff94d684886df0
+  - enabled: 1
+    path: Assets/Scenes/SandyBeach_Copy.unity
+    guid: a5e78cd9db39e994780b1449073cffba
+  - enabled: 1
+    path: Assets/Scenes/SandyCave_Copy.unity
+    guid: 5b84e1a562921b14d9e9adb4b7a586c6
+  - enabled: 1
+    path: Assets/Scenes/Shore_Copy.unity
+    guid: 337aa51ad2413694e8c24feb481177f6
+  - enabled: 1
+    path: Assets/Scenes/River4_Copy.unity
+    guid: dceee0c62cb03b74c9fe7a9a9c457f1d
   m_configObjects: {}


### PR DESCRIPTION
Resized panel under Console_UI/Console/ConsoleCanvas/Panel (scene view) so that the inventory button can be clicked in all scenes. Prior to this, the panel spanned the whole screen as an invisible image and prevented pointer clicks from being captured.